### PR TITLE
GPU Computing

### DIFF
--- a/isettools/gui/vcAddAndSelectObject.m
+++ b/isettools/gui/vcAddAndSelectObject.m
@@ -33,7 +33,10 @@ global vcSESSION;
 % vcAddAndSelectObject(scene) instead of
 % vcAddAndSelectObject('scene',scene), which was the original 
 %
-if checkfields(objType,'type'), obj = objType; objType = objType.type;  end
+if checkfields(objType,'type'), obj = objType; objType = objType.type; end
+
+% gather to avoid distributed component (e.g. gpuArray)
+obj = gatherStruct(obj);
 
 % Makes objType proper type and forces upper case.
 objType = vcEquivalentObjtype(objType);

--- a/isettools/gui/vcAddObject.m
+++ b/isettools/gui/vcAddObject.m
@@ -31,6 +31,9 @@ global vcSESSION;
 objType = obj.type;
 val = vcNewObjectValue(objType);
 
+% gather to avoid distributed component (e.g. gpuArray)
+obj = gatherStruct(obj);
+
 %% Assign object to the vcSESSION global.
 
 % Should be ieSessionSet, not this.

--- a/isettools/main/ieInitSession.m
+++ b/isettools/main/ieInitSession.m
@@ -49,5 +49,12 @@ if ~checkfields(iePref,'waitbar')
 else vcSESSION.GUI.waitbar = iePref.waitbar;
 end
 
-return;
+% Check gpu computing
+try
+    gpuArray(0);
+    vcSESSION.GPUCOMPUTE = true;
+catch 
+    vcSESSION.GPUCOMPUTE = false;
+end
 
+end

--- a/isettools/main/ieSessionGet.m
+++ b/isettools/main/ieSessionGet.m
@@ -105,11 +105,12 @@ switch param
         end
         
     % Matlab setpref/getpref 
-    case {'detlafontsize','fontsize','fontincrement','increasefontsize','fontdelta','deltafont'}
-        % This value determines whether we change the font size in every window
-        % by this increment, calling ieFontChangeSize when the window is
-        % opened.
-        % if checkfields(vcSESSION,'FONTSIZE'), val = vcSESSION.FONTSIZE;  end
+    case {'detlafontsize', 'fontsize', 'fontincrement', ...
+            'increasefontsize', 'fontdelta', 'deltafont'}
+        % This value determines whether we change the font size in every
+        % window by this increment, calling ieFontChangeSize when the
+        % window is opened. if checkfields(vcSESSION,'FONTSIZE'), val =
+        % vcSESSION.FONTSIZE;  end
         isetPref = getpref('ISET');
         if ~isempty(isetPref)
             if checkfields(isetPref,'fontDelta'), val = isetPref.fontDelta; 
@@ -118,17 +119,18 @@ switch param
             val = 0; 
         end
         if isempty(val), val = 0; end
-        %     case {'whitepoint'}
-        %         % The white point default is equal photon maps to (1,1,1)
-        %         % You can set to equal energy ('ee') or Daylight 6500 (d65).
-        %         isetPref = getpref('ISET');
-        %         if ~isempty(isetPref)
-        %             if checkfields(isetPref,'whitePoint'), val = isetPref.whitePoint;
-        %             else val = 'ep';
-        %             end
-        %         else
-        %             val = 'ep';  % Equal photon
-        %         end
+%     case {'whitepoint'}
+%         % The white point default is equal photon maps to (1,1,1)
+%         % You can set to equal energy ('ee') or Daylight 6500 (d65).
+%         isetPref = getpref('ISET');
+%         if ~isempty(isetPref)
+%             if checkfields(isetPref,'whitePoint')
+%                 val = isetPref.whitePoint;
+%             else val = 'ep';
+%             end
+%         else
+%             val = 'ep';  % Equal photon
+%         end
         
     case {'waitbar'}
         % Used to decide whether we show the waitbars.
@@ -176,7 +178,7 @@ switch param
     case {'ipguidata','vciguidata','vciwindowhandle','vcimagehandle','vcimagehandles','processorwindowhandles','processorhandles','processorhandle','processorimagehandle'}
         v = ieSessionGet('vcimagefigure');
         if ~isempty(v), val = guihandles(v); end
-    case {'metricguidata','metricshandle','metricshandles','metricswindowhandles','metricswindowhandles','metricswindowhandle'}
+    case {'metricguidata','metricshandle','metricshandles','metricswindowhandles','metricswindowhandle'}
         v = ieSessionGet('vcimagefigure');
         if ~isempty(v), val = guihandles(v); end
         
@@ -204,7 +206,7 @@ switch param
             val = vcSESSION.GUI.vcImageWindow.hObject;
         end
         
-    case {'metricsfigure','metricswindow','metricswindow','metricsfigures'}
+    case {'metricsfigure','metricswindow','metricsfigures'}
         if checkfields(vcSESSION,'GUI','metricsWindow')
             val = vcSESSION.GUI.metricsWindow.hObject;
         end

--- a/isettools/main/ieSessionGet.m
+++ b/isettools/main/ieSessionGet.m
@@ -149,8 +149,14 @@ switch param
             vcSESSION.GUI.waitbar = val;
         end
         
-        
-        
+    case {'gpu', 'gpucompute', 'gpucomputing'}
+        if isfield(vcSESSION, 'GPUCOMPUTE')
+            val = vcSESSION.GPUCOMPUTE;
+        else % do a simple test here
+            val = true;
+            try gpuArray(0); catch, val = false; end
+            vcSESSION.GPUCOMPUTE = val;
+        end
     case {'graphwinstructure'}
         val = vcSESSION.GRAPHWIN;
     case {'graphwinfigure'}

--- a/isettools/main/ieSessionSet.m
+++ b/isettools/main/ieSessionSet.m
@@ -113,7 +113,7 @@ switch param
     case {'help','inithelp'}
         % Default for help is true, if the initHelp has not been set.
         if checkfields(vcSESSION,'initHelp'), vcSESSION.initHelp = val;
-        else vcSESSION.initHelp = 1; val = 1;
+        else vcSESSION.initHelp = 1;
         end
         
         % Matlab setpref values
@@ -145,6 +145,8 @@ switch param
         %         % It is also possible to choose 'ee' (equal energy), or 'd65'.  If
         %         % the value is unrecognized, the default is used.
         %         setpref('ISET','whitePoint',val);
+    case {'gpu', 'gpucompute', 'gpucomputing'}
+        vcSESSION.GPUCOMPUTE = val;
         
         
         % Set window information at startup

--- a/isettools/opticalimage/oiCalculateOTF.m
+++ b/isettools/opticalimage/oiCalculateOTF.m
@@ -20,14 +20,14 @@ function [otf,fSupport] = oiCalculateOTF(oi,wave,unit)
 %
 % Copyright ImagEval Consultants, LLC, 2005.
 
-if notDefined('wave'), wave = sceneGet(oi, 'wave'); end
+if notDefined('wave'), wave = oiGet(oi, 'wave'); end
 if notDefined('unit'), unit = 'cyclesPerDegree'; end
 
 optics = oiGet(oi,'optics');
 opticsModel = opticsGet(optics,'model');
 
 % Retrieve the frequency support in the proper units.
-fSupport = oiGet(oi,'frequencysupport',unit);
+fSupport = oiGet(oi, 'frequencysupport',unit);
 
 switch lower(opticsModel)
     case {'dlmtf','diffractionlimited'}

--- a/isettools/opticalimage/oiPad.m
+++ b/isettools/opticalimage/oiPad.m
@@ -36,7 +36,7 @@ if ismatrix(padSize), padSize(3) = 0; end
 photons = oiGet(oi,'photons');
 % To prevent ieCompressData error, we set the surrounding region as the
 % mean of the data
-padval = mean(photons(:));
+padval = gather(mean(photons(:)));
 
 try
     photons = padarray(photons,padSize,padval,direction);

--- a/isettools/opticalimage/oiSet.m
+++ b/isettools/opticalimage/oiSet.m
@@ -171,8 +171,8 @@ switch parm
         oi.data = val;
 
     case {'cphotons', 'compressedphotons', 'photons'}
-        if ~(isa(val, 'double') || isa(val, 'single')),
-            error('Photons must be type double or single.');
+        if ~(isa(val, 'double') || isa(val, 'single') || isa(val, 'gpuArray')),
+            error('Photons must be type double / single / gpuArray');
         end
         
         bitDepth = oiGet(oi, 'bitDepth');

--- a/isettools/scene/sceneCreate.m
+++ b/isettools/scene/sceneCreate.m
@@ -506,7 +506,7 @@ if ~notDefined('scene.data.photons')
         v = sceneGet(scene, 'peakRadianceAndWave');
         idxWave = find(wave == v(2));
         p = sceneGet(scene, 'photons', v(2));
-        [tmp, ij] = max2(p); %#ok<ASGLU>
+        [~, ij] = max2(p);
         v = [0.9 ij(1) ij(2) idxWave];
         scene = sceneSet(scene,'knownReflectance',v);
     end
@@ -517,6 +517,11 @@ if ~notDefined('scene.data.photons')
     % This routine also adjusts the illumination level to be consistent
     % with the reflectance and scene photons.
     scene = sceneAdjustLuminance(scene,100);
+    
+    if ieSessionGet('gpu compute')
+        p = sceneGet(scene, 'photons');
+        scene = sceneSet(scene, 'photons', gpuArray(p));
+    end
 end
 
 end

--- a/isettools/scene/sceneFromFile.m
+++ b/isettools/scene/sceneFromFile.m
@@ -98,9 +98,8 @@ switch lower(imType)
         il    = illuminantCreate('d65',wave);
         % Replace default with white point
         il    = illuminantSet(il,'energy',sum(d.spd,2));
-        scene = sceneSet(scene,'illuminant',il);
+        scene = sceneSet(scene, 'illuminant', il);
     case {'multispectral','hyperspectral'}
-        
         if ~ischar(I), error('File name required for multispectral'); end
         if notDefined('wList'), wList = []; end
         
@@ -125,9 +124,9 @@ switch lower(imType)
 end
 
 %% Put all the parameters in place and return
-scene = sceneSet(scene,'filename',I);
-scene = sceneSet(scene,'photons',photons);
-scene = sceneSet(scene,'illuminant',il);
+scene = sceneSet(scene, 'filename', I);
+scene = sceneSet(scene, 'photons', photons);
+scene = sceneSet(scene, 'illuminant', il);
 
 % The file name or just announce that we received rgb data
 if ischar(I), [~, n, ~] = fileparts(I);
@@ -136,8 +135,8 @@ end
 if exist('d', 'var'), n = [n ' - ' displayGet(d, 'name')]; end
 scene = sceneSet(scene,'name',n);
 
-if notDefined('meanLuminance')
-else  scene = sceneAdjustLuminance(scene,meanLuminance); % Adjust mean
+if ~notDefined('meanLuminance')
+    scene = sceneAdjustLuminance(scene,meanLuminance); % Adjust mean
 end
 
 if ~notDefined('wList')

--- a/isettools/scene/sceneFromFile.m
+++ b/isettools/scene/sceneFromFile.m
@@ -124,6 +124,10 @@ switch lower(imType)
 end
 
 %% Put all the parameters in place and return
+if ieSessionGet('gpu compute')
+    photons = gpuArray(photons);
+end
+
 scene = sceneSet(scene, 'filename', I);
 scene = sceneSet(scene, 'photons', photons);
 scene = sceneSet(scene, 'illuminant', il);

--- a/isettools/scene/sceneInterpolateW.m
+++ b/isettools/scene/sceneInterpolateW.m
@@ -103,13 +103,17 @@ if ~isempty(photons)
         newPhotons = XW2RGBFormat(newPhotons,row,col);
     else
         % Big data set condition, so we loop down the rows
-        newPhotons = zeros(r,c,length(waveSpectrum.wave));
+        if ieSessionGet('gpu compute')
+            newPhotons = zeros(r,c,length(waveSpectrum.wave), 'gpuArray');
+        else
+            newPhotons = zeros(r,c,length(waveSpectrum.wave));
+        end
         for rr=1:r
             % Get a row
             pRow = squeeze(photons(rr,:,:))';
             % Interpolate all the columns in that row and put it in place
             newPhotons(rr,:,:) = interp1(curWave(:),pRow,...
-                waveSpectrum.wave(:),'linear')';
+                waveSpectrum.wave(:), 'linear')';
         end
     end
     

--- a/utility/gatherStruct.m
+++ b/utility/gatherStruct.m
@@ -1,0 +1,37 @@
+function obj = gatherStruct(obj)
+% Gather distributed struct to current working directory
+%   function obj = gatherStruct(obj)
+%
+% Input:
+%   obj  - variable or structure, for structure, we will gather recursively
+%          for all its sub-field
+%
+% Output:
+%   obj  - gathered obj
+%
+% Example:
+%   scene = sceneCreate;
+%   scene = gather(scene);
+%
+% Note:
+%   This function is only useful in context of gpu computing. If there's
+%   no distributed field (e.g. gpuArray) in obj, the output will be the
+%   same as input
+%
+% See also:
+%   gather, vcAddObject, vcAddAndSelectObject
+%
+% (HJ) ISETBIO TEAM, 2014
+
+if notDefined('obj'), obj = []; return; end
+
+if isstruct(obj)
+    fNames = fieldnames(obj);
+    for ii = 1:length(fNames)
+        obj.(fNames{ii}) = gatherStruct(obj.(fNames{ii}));
+    end
+else
+    obj = gather(obj);
+end
+
+end


### PR DESCRIPTION
This pull request is mainly for some update for gpu computing in ISETBIO. It consists of following part:
1. add 'gpu compute' as a parameter of vcSESSION. User could now turn-on / off gpu computing by ieSessionSet('gpu compute', true/false);
2. Remove the stand-alone code for gpu computing for oiCompute (actually customOTF and opticsOTF). Now  GPU computing and CPU computing use the same code. The only difference is matrix type (GPU - gpuArray, CPU - double/single matrix)
3. If we do gpu computing, the scene we created will be on GPU. The oi data will be on GPU. The sensor data will be on GPU. Thus, it's not like previous version where GPU computing only took place in oi compute.
4. Add routines to convert gpu object (scene/oi/sensor) back to main memory. This function is used very time we call vcAddObject and vcAddAndSelectObject to avoid potential GUI issues. If the object is already in main memory, nothing will happen.

GPU computing requires Matlab 2014a and CUDA enabled machine. Maybe it's hard for some people to test or use, but I guess we would like it some day.

Best,
HJ
